### PR TITLE
Update README.md / make it findable in Hoobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note that it might be neccessary to enter the search string inside double quotes
 
 ## Configuration
 
-configure the plugin in the GUI / [Homebridge Config UI X](https://github.com/oznu/homebridge-config-ui-x) (highly recommended), otherwise head over to [Manual Config](#manual-config)
+Configure the plugin in the GUI / [Homebridge Config UI X](https://github.com/oznu/homebridge-config-ui-x) (highly recommended), otherwise head over to [Manual Config](#manual-config)
 
  <img title="Settings: Xiaomi Mi Air Purifier" src="../assets/media/settings-xiaomi-mi-air-purifier.png" width="726">
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Install using `npm`:
 npm install -g homebridge-xiaomi-mi-air-purifier
 ```
 
-Or, search for `homebridge-xiaomi-mi-air-purifier ` in Plugins.
+Or, search for `homebridge-xiaomi-mi-air-purifier ` in Plugins. Note that it might be neccessary to enter the search string inside double quotes i.e. `"homebridge-xiaomi-mi-air-purifier"` in some Homebridge UI variants (such as [Hoobs](https://hoobs.com/)) in order to find it among the plethora of similarly named plugins.
 
 ## Configuration
 
-Use [Homebridge Config UI X](https://github.com/oznu/homebridge-config-ui-x) to configure the plugin (highly recommended) otherwise head over to [Manual Config](#manual-config)
+configure the plugin in the GUI / [Homebridge Config UI X](https://github.com/oznu/homebridge-config-ui-x) (highly recommended), otherwise head over to [Manual Config](#manual-config)
 
  <img title="Settings: Xiaomi Mi Air Purifier" src="../assets/media/settings-xiaomi-mi-air-purifier.png" width="726">
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Install using `npm`:
 npm install -g homebridge-xiaomi-mi-air-purifier
 ```
 
-Or, search for `homebridge-xiaomi-mi-air-purifier ` in Plugins. Note that it might be neccessary to enter the search string inside double quotes i.e. `"homebridge-xiaomi-mi-air-purifier"` in some Homebridge UI variants (such as [Hoobs](https://hoobs.com/)) in order to find it among the plethora of similarly named plugins.
+Or, search for `homebridge-xiaomi-mi-air-purifier ` in Plugins. 
+
+Note that it might be neccessary to enter the search string inside double quotes i.e. `"homebridge-xiaomi-mi-air-purifier"` in some Homebridge UI variants (such as [Hoobs](https://hoobs.com/)) in order to find it among the plethora of similarly named plugins.
 
 ## Configuration
 


### PR DESCRIPTION
I don't know about the stock UI X, but in the [Hoobs distro](https://hoobs.com/) it is all but impossible to know which one of the almost identically named plugins we are looking for. This can be alleviated by searching for the exact, quoted, NPM module name instead.